### PR TITLE
Remove --without-common_test flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ RUN \
       --without-debugger \
       --without-observer \
       --without-jinterface \
-      --without-common_test \
       --without-cosEvent\
       --without-cosEventDomain \
       --without-cosFileTransfer \


### PR DESCRIPTION
Hi Paul, 

First be aware that I'm not yet very familiar with building Erlang.

We've been facing issues while compiling rabbitmq dependencies when working with Elixir 

```
/app/deps/rabbit_common/src/rabbit_ct_broker_helpers.erl:19: can't find include lib "common_test/include/ct.hrl"
```

After investigating, we've found that it boils down to `common_tests` being skipped when Erlang is compiled in `alpine-erlang`. Re-adding leads to just a 3mb larger image. 

I don't know if that makes sense to merge this, given my understanding is: 
- that using releases (with `distillery` thanks for writing it 💪  ) would negates the problem in the problem in the first place as we'd be compiling locally, where we'd have `common_test` included and then just placing the release in the docker image.
- still, if we'd be building releases in docker images based on `alpine-erlang` we'd hit the same problem (it's simpler to build releases in docker images and copying it in another one than having to deal with OTP versions directly on our building machines). 