### PR TITLE
Add dialyzer for static code analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2017-10-01 \
+ENV REFRESHED_AT=2017-10-06 \
     LANG=en_US.UTF-8 \
     HOME=/opt/app/ \
     # Set this so that CTRL+G works properly
@@ -62,7 +62,6 @@ RUN \
       --without-cosProperty \
       --without-cosTime \
       --without-cosTransactions \
-      --without-dialyzer \
       --without-et \
       --without-gs \
       --without-ic \


### PR DESCRIPTION
I'd like to propose to add dialyzer, as it's widely used in development and your alpine-elixir image is based on this erlang image.

The compressed image size difference is ~1 MB ([52 MB](https://hub.docker.com/r/arnodirlam/alpine-erlang/tags/) forked image as compared to [51 MB](https://hub.docker.com/r/bitwalker/alpine-erlang/tags/)), so it's probably not worth the hassle to maintain a separate image tag just for dialyzer inclusion, IMHO.

Let me know what you think.