### PR TITLE
Build Erlang with musl target on Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN \
       zlib-dev@main && \
     # Install Erlang/OTP build deps
     apk add --no-cache --virtual .erlang-build \
+      dpkg-dev@main dpkg@main \
       git@main autoconf@main build-base@main perl-dev@main && \
     # Shallow clone Erlang/OTP
     git clone -b OTP-$ERLANG_VERSION --single-branch --depth 1 https://github.com/erlang/otp.git . && \
@@ -49,6 +50,7 @@ RUN \
     # Configure
     ./otp_build autoconf && \
     ./configure --prefix=/usr \
+      --build="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
       --sysconfdir=/etc \
       --mandir=/usr/share/man \
       --infodir=/usr/share/info \


### PR DESCRIPTION
While debugging issue https://github.com/appsignal/appsignal-elixir/issues/273 we found out that the bitwalker/alpine-elixir image returns the `'x86_64-unknown-linux-gnu'` value for the `:erlang.system_info(:system_architecture)` call.

Turns out the bitwalker/alpine-erlang image returns the same value for `erlang:system_info(system_architecture).`.

Looking at the official Erlang Docker image (https://hub.docker.com/_/erlang/) I saw that they specify the build target during `./configure` step, using the output from `dpkg-architecture --query DEB_BUILD_GNU_TYPE`. Applied the same logic to the bitwalker/erlang image in order to have `erlang:system_info(system_architecture).` return the correct host triple.

With this change `erlang:system_info(system_architecture).` will return `"x86_64-pc-linux-musl"` as the value.

This change allows packages that rely on this value for system architecture detection to select the proper Alpine Linux library for compilation, such as the AppSignal for Elixir package.

---

Let me know if there's anything else I can do to help this problem get fixed!
