### PR TITLE
Update tagged Alpine repos to use same version as image base (v3.7)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2017-12-18 \
+ENV REFRESHED_AT=2018-01-17 \
     LANG=en_US.UTF-8 \
     HOME=/opt/app/ \
     # Set this so that CTRL+G works properly
@@ -22,8 +22,8 @@ RUN \
     adduser -s /bin/sh -u 1001 -G root -h ${HOME} -S -D default && \
     chown -R 1001:0 ${HOME} && \
     # Add tagged repos as well as the edge repo so that we can selectively install edge packages
-    echo "@main http://dl-cdn.alpinelinux.org/alpine/v3.6/main" >> /etc/apk/repositories && \
-    echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories && \
+    echo "@main http://dl-cdn.alpinelinux.org/alpine/v3.7/main" >> /etc/apk/repositories && \
+    echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.7/community" >> /etc/apk/repositories && \
     echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     # Upgrade Alpine and base packages
     apk --no-cache upgrade && \


### PR DESCRIPTION
The image is based on Alpine Linux v3.7, but adds v3.6 repos. It creates some very creative error messages when you try to add new packages later down the chain.

**Examples:**
When trying to add nodejs-current and yarn:
```
ERROR: unsatisfiable constraints:
  Huh? Error reporter did not find the broken constraints.
```

When: Trying to add python3
```
ERROR: unsatisfiable constraints:
  libressl2.5-libssl-2.5.5-r0:
    masked in: @main
    satisfies: python3-3.6.1-r3[so:libssl.so.43]
  python3-3.6.1-r3:
    masked in: @main
    satisfies: world[python3]
```