### PR TITLE
chore(Dockerfile): Replace -dev packages with non-dev versions for fi…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.10 AS build
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2019-06-21 \
+ENV REFRESHED_AT=2019-07-09 \
     LANG=en_US.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \
@@ -143,10 +143,10 @@ RUN \
     apk add --no-cache --update \
       bash \
       ca-certificates \
-      openssl-dev \
-      ncurses-dev \
-      unixodbc-dev \
-      zlib-dev && \
+      openssl \
+      ncurses \
+      unixodbc \
+      zlib && \
     # Update ca certificates
     update-ca-certificates --fresh
 


### PR DESCRIPTION
…nal image

@bitwalker Changes based on the discussion in #55. The only additional question I would have now is why are we downloading both `dpkg-dev` and `dpkg` on lines 36 and 37 of the build image. Shouldn't we be able to get away with just using `dpkg-dev` here?