### PR TITLE
chore(ERLANG_VERSION): Update to 23.2.5

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 23.2.3
+erlang 23.2.5
 alpine 3.13.1


### PR DESCRIPTION
@bitwalker A new patch version of erlang has been released.

https://erlang.org/download/OTP-23.2.5.README