### PR TITLE
chore(ALPINE_VERSION): Update to 3.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-01-31 \
+ENV REFRESHED_AT=2021-02-17 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 erlang 23.2.5
-alpine 3.13.1
+alpine 3.13.2


### PR DESCRIPTION
@bitwalker The maintainers of Alpine Linux have released a new patch version. This release mainly includes updates to packages and fixes a CVE in OpenSSL.

https://www.openssl.org/news/secadv/20210216.txt
https://git.alpinelinux.org/cgit/aports/log/?h=v3.13.2