### PR TITLE
bugfix(Release): Do not use build as the target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ release: setup-buildx ## Build and release the Docker image to Docker Hub
 		--build-arg ERLANG_VERSION=$(VERSION) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_MIN_VERSION=$(ALPINE_MIN_VERSION) \
-		--target=build \
 		--platform linux/amd64,linux/arm64 \
 		--cache-from "type=local,src=$(BUILDX_CACHE_DIR)" \
 		--cache-to "type=local,dest=$(BUILDX_CACHE_DIR)" \


### PR DESCRIPTION
@bitwalker It looks like we have an issue with the build pipeline as we are pushing the `build` section of the Dockerfile to Docker hub. For some background here is what I ran into and how I debugged the issue.

I came across production builds that were no longer working. I was getting an error when compiling elixir that essentially boiled down to the system telling me that erlang was not installed. I thought this was odd as everything looked good to me when we made the changes to get buildx up and running. So I created two debug Dockerfiles with the most recent version of alpine-erlang and the most recent working version (which is v23.2.2). One thing I noticed off the bat was the working version's image size was much smaller than the non working version (371MB vs 764MB). When I executed the containers, I could confirm `which erl` did not work in the most recent version. I did some more investigating and noticed that I still had the `/tmp/erlang-build` directory which was the smoking gun that let me know the full file had not been parsed. I could confirm this by looking at the image layers listed in Docker hub. 

https://hub.docker.com/layers/bitwalker/alpine-erlang/23.2.2/images/sha256-326e0485d18be964cc6c97a2eb971ef6e0b2efe59013defe0b7f0809bd467c88?context=explore

https://hub.docker.com/layers/bitwalker/alpine-erlang/23.2.5/images/sha256-e90f5a6e3e81f0de286669ddfa537bca5e0a99fa102185e8b26671975a02f47a?context=explore

I believe by just removing the target line, the issue should be resolved. Please let me know if I missed anything.