### PR TITLE
chore(ERLANG_VERSION): Update to 23.2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ release: setup-buildx ## Build and release the Docker image to Docker Hub
 		--build-arg ERLANG_VERSION=$(VERSION) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
 		--build-arg ALPINE_MIN_VERSION=$(ALPINE_MIN_VERSION) \
-		--target=build \
 		--platform linux/amd64,linux/arm64 \
 		--cache-from "type=local,src=$(BUILDX_CACHE_DIR)" \
 		--cache-to "type=local,dest=$(BUILDX_CACHE_DIR)" \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 23.2.5
+erlang 23.2.6
 alpine 3.13.2


### PR DESCRIPTION
@bitwalker There has been another patch release of erlang. Also includes changes from #96. 

https://erlang.org/download/OTP-23.2.6.README