### PR TITLE
chore(ERLANG_VERSION): Update to 23.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-05-06 \
+ENV REFRESHED_AT=2021-05-10 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-04-27 \
+ENV REFRESHED_AT=2021-05-06 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 23.3.3
+erlang 23.3.4
 alpine 3.13.5

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 23.3.2
+erlang 23.3.3
 alpine 3.13.5


### PR DESCRIPTION
@bitwalker A recent patch version of erlang has been released.

https://erlang.org/download/OTP-23.3.3.README