### PR TITLE
chore(ALPINE + ERLANG): Update to alpine 3.14.1 and erlang 24.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
-        otp: [23.3.4.5, 24.0.4]
-        alpine: [3.14.0]
+        otp: [23.3.4.5, 24.0.5]
+        alpine: [3.14.1]
         latest: [false]
         include:
-          - otp: 24.0.4
-            alpine: 3.14.0
+          - otp: 24.0.5
+            alpine: 3.14.1
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-06-08 \
+ENV REFRESHED_AT=2021-08-05 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.0.4
-alpine 3.14.0
+erlang 24.0.5
+alpine 3.14.1


### PR DESCRIPTION
@bitwalker Updates to newest version of Alpine and Erlang.

https://erlang.org/download/OTP-24.0.5.README
https://alpinelinux.org/posts/Alpine-3.14.1-released.html