### PR TITLE
chore(Erlang): Update to version 24.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
-        otp: [23.3.4.6, 24.0.6]
-        alpine: [3.14.1]
+        otp: [23.3.4.7, 24.1.1]
+        alpine: [3.14.2]
         latest: [false]
         include:
-          - otp: 24.0.6
+          - otp: 24.1.1
             alpine: 3.14.2
             latest: true
     steps:

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.0.6
+erlang 24.1.1
 alpine 3.14.2


### PR DESCRIPTION
@bitwalker Updates erlang to 24.1.1

https://erlang.org/download/OTP-24.1.README
https://erlang.org/download/OTP-24.1.1.README