### PR TITLE
chore(Erlang): Update to version 24.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
-        otp: [23.3.4.7, 24.1.2]
+        otp: [23.3.4.8, 24.1.4]
         alpine: [3.14.2]
         latest: [false]
         include:
-          - otp: 24.1.2
+          - otp: 24.1.4
             alpine: 3.14.2
             latest: true
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-10-12 \
+ENV REFRESHED_AT=2021-11-08 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.1.2
+erlang 24.1.4
 alpine 3.14.2


### PR DESCRIPTION
@bitwalker Updates erlang to most recent version.

https://erlang.org/download/OTP-24.1.3.README
https://erlang.org/download/OTP-24.1.4.README