### PR TITLE
chore(Alpine): Update to version 3.14.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     strategy: 
       matrix: 
         otp: [23.3.4.8, 24.1.4]
-        alpine: [3.14.2]
+        alpine: [3.14.3]
         latest: [false]
         include:
           - otp: 24.1.4
-            alpine: 3.14.2
+            alpine: 3.14.3
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-11-08 \
+ENV REFRESHED_AT=2021-11-12 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 erlang 24.1.4
-alpine 3.14.2
+alpine 3.14.3


### PR DESCRIPTION
@bitwalker Updates alpine to the latest released version.

https://alpinelinux.org/posts/Alpine-3.14.3-released.html