### PR TITLE
chore(Erlang): Update to version 24.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
-        otp: [23.3.4.8, 24.1.4]
+        otp: [23.3.4.9, 24.1.5]
         alpine: [3.14.3]
         latest: [false]
         include:
-          - otp: 24.1.4
+          - otp: 24.1.5
             alpine: 3.14.3
             latest: true
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-11-12 \
+ENV REFRESHED_AT=2021-11-14 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.1.4
+erlang 24.1.5
 alpine 3.14.3


### PR DESCRIPTION
@bitwalker Updates erlang to 24.1.5 and 23.3.4.9. 

https://erlang.org/download/OTP-23.3.4.9.README
https://erlang.org/download/OTP-24.1.5.README