### PR TITLE
chore(ALPINE + ERLANG): Update to alpine 3.15.0 and erlang 24.1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy: 
       matrix: 
-        otp: [23.3.4.9, 24.1.5]
-        alpine: [3.14.3]
+        otp: [23.3.4.9, 24.1.7]
+        alpine: [3.15.0]
         latest: [false]
         include:
-          - otp: 24.1.5
-            alpine: 3.14.3
+          - otp: 24.1.7
+            alpine: 3.15.0
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2021-11-14 \
+ENV REFRESHED_AT=2021-12-10 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.1.5
-alpine 3.14.3
+erlang 24.1.7
+alpine 3.15.0


### PR DESCRIPTION
@bitwalker Updates erlang and alpine to most recent versions.

https://alpinelinux.org/posts/Alpine-3.15.0-released.html
https://erlang.org/download/OTP-24.1.6.README
https://erlang.org/download/OTP-24.1.7.README