### PR TITLE
chore(ALPINE + ERLANG): Update to alpine 3.15.1 and erlang 24.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23.3.4.9, 24.2.2]
-        alpine: [3.15.0]
+        otp: [23.3.4.9, 24.3.2]
+        alpine: [3.15.1]
         latest: [false]
         include:
-          - otp: 24.2.2
-            alpine: 3.15.0
+          - otp: 24.3.2
+            alpine: 3.15.1
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2022-02-25 \
+ENV REFRESHED_AT=2022-03-16 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.2.2
-alpine 3.15.0
+erlang 24.3.2
+alpine 3.15.1


### PR DESCRIPTION
@bitwalker updates alpine and erlang to most recent versions.

https://alpinelinux.org/posts/Alpine-3.15.1-released.html
https://erlang.org/download/OTP-24.3.README
https://erlang.org/download/OTP-24.3.1.README
https://erlang.org/download/OTP-24.3.2.README