### PR TITLE
chore(Alpine): Update to version 3.15.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       matrix:
         otp: [23.3.4.9, 24.3.2]
-        alpine: [3.15.1]
+        alpine: [3.15.2]
         latest: [false]
         include:
           - otp: 24.3.2
-            alpine: 3.15.1
+            alpine: 3.15.2
             latest: true
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       matrix:
         otp: [23.3.4.9, 24.3.2]
-        alpine: [3.15.2]
+        alpine: [3.15.3]
         latest: [false]
         include:
           - otp: 24.3.2
-            alpine: 3.15.2
+            alpine: 3.15.3
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2022-03-16 \
+ENV REFRESHED_AT=2022-03-23 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 erlang 24.3.2
-alpine 3.15.2
+alpine 3.15.3

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 erlang 24.3.2
-alpine 3.15.1
+alpine 3.15.2


### PR DESCRIPTION
@bitwalker Updates Alpine linux to 3.15.2. May take a sec for docker images to be built.

https://alpinelinux.org/posts/Alpine-3.15.2-released.html