### PR TITLE
chore(ERLANG): Update to version 24.3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23.3.4.9, 24.3.2]
+        otp: [23.3.4.13, 24.3.3]
         alpine: [3.15.3]
         latest: [false]
         include:
-          - otp: 24.3.2
+          - otp: 24.3.3
             alpine: 3.15.3
             latest: true
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2022-03-23 \
+ENV REFRESHED_AT=2022-03-30 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 24.3.2
+erlang 24.3.3
 alpine 3.15.3


### PR DESCRIPTION
@bitwalker Updates erlang to 24.3.3 and 23.3.4.13

https://erlang.org/download/OTP-24.3.3.README

https://erlang.org/download/OTP-23.3.4.10.README
https://erlang.org/download/OTP-23.3.4.11.README
https://erlang.org/download/OTP-23.3.4.12.README
https://erlang.org/download/OTP-23.3.4.13.README