### PR TITLE
chore(Alpine): Update to version 3.15.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       matrix:
         otp: [23.3.4.13, 24.3.3]
-        alpine: [3.15.3]
+        alpine: [3.15.4]
         latest: [false]
         include:
           - otp: 24.3.3
-            alpine: 3.15.3
+            alpine: 3.15.4
             latest: true
     steps:
     - name: Checkout

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 erlang 24.3.3
-alpine 3.15.3
+alpine 3.15.4


### PR DESCRIPTION
@bitwalker A new release of Alpine has been created to fix a CVE in busybox.

https://alpinelinux.org/posts/Alpine-3.12.12-3.13.10-3.14.6-3.15.4-released.html
https://security.alpinelinux.org/vuln/CVE-2022-28391