### PR TITLE
chore(ALPINE + ERLANG): use version 3.16.1 of alpine and 25.0.3 of er…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23.3.4.13, 24.3.4, 25.0.2]
-        alpine: [3.15.4]
+        otp: [23.3.4.16, 24.3.4.2, 25.0.3]
+        alpine: [3.16.1]
         latest: [false]
         include:
-          - otp: 25.0.2
-            alpine: 3.15.4
+          - otp: 25.0.3
+            alpine: 3.16.1
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2022-07-25 \
+ENV REFRESHED_AT=2022-07-26 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 25.0.2
-alpine 3.15.4
+erlang 25.0.3
+alpine 3.16.1


### PR DESCRIPTION
…lang. @bitwalker LMKWYT

https://alpinelinux.org/posts/Alpine-3.16.0-released.html
https://alpinelinux.org/posts/Alpine-3.16.1-released.html

https://erlang.org/download/OTP-25.0.3.README