### PR TITLE
chore(Alpine): Update to version 3.16.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       matrix:
         otp: [23.3.4.16, 24.3.4.2, 25.0.3]
-        alpine: [3.16.1]
+        alpine: [3.16.2]
         latest: [false]
         include:
           - otp: 25.0.3
-            alpine: 3.16.1
+            alpine: 3.16.2
             latest: true
     steps:
     - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ERLANG_VERSION
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2022-07-26 \
+ENV REFRESHED_AT=2022-08-12 \
     LANG=C.UTF-8 \
     HOME=/opt/app/ \
     TERM=xterm \

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 erlang 25.0.3
-alpine 3.16.1
+alpine 3.16.2


### PR DESCRIPTION
@bitwalker Updates to alpine 3.16.2 which fixes a CVE in zlib. 

https://security.alpinelinux.org/vuln/CVE-2022-37434