### PR TITLE
chore(Alpine + Erlang): Update to alpine 3.17.0 and erlang 25.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23.3.4.18, 24.3.4.6, 25.0.4, 25.1.2]
-        alpine: [3.16.3]
+        otp: [23.3.4.18, 24.3.4.7, 25.0.4, 25.1.2, 25.2]
+        alpine: [3.17.0]
         latest: [false]
         include:
-          - otp: 25.1.2
-            alpine: 3.16.3
+          - otp: 25.2
+            alpine: 3.17.0
             latest: true
     steps:
     - name: Checkout

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-erlang 25.1.2
-alpine 3.16.3
+erlang 25.2
+alpine 3.17.0


### PR DESCRIPTION
@bitwalker LMKWYT

https://alpinelinux.org/posts/Alpine-3.17.0-released.html
https://erlang.org/download/OTP-25.2.README